### PR TITLE
Fix the concurrent problem of caching the last token result in StatsSlot

### DIFF
--- a/sentinel-core/common/BUILD
+++ b/sentinel-core/common/BUILD
@@ -49,6 +49,7 @@ cc_library(
   copts = DEFAULT_COPTS,
   deps = [
     "//sentinel-core/statistic/node:node_interface",
+    "//sentinel-core/slot/base:token_result_lib",
   ]
 )
 

--- a/sentinel-core/common/entry_context.h
+++ b/sentinel-core/common/entry_context.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include "sentinel-core/slot/base/token_result.h"
 #include "sentinel-core/statistic/node/node.h"
 
 namespace Sentinel {
@@ -16,9 +17,21 @@ class EntryContext {
   const std::string& name() const { return name_; };
   const std::string& origin() const { return origin_; };
 
+  const Slot::TokenResultSharedPtr& last_token_result() const {
+    return last_token_result_;
+  }
+  /**
+   * Users should not invoke this.
+   */
+  void set_last_token_result(const Slot::TokenResultSharedPtr& r) {
+    last_token_result_ = r;
+  }
+
  private:
   const std::string name_;
   const std::string origin_;
+
+  Slot::TokenResultSharedPtr last_token_result_;
 };
 
 using EntryContextSharedPtr = std::shared_ptr<EntryContext>;

--- a/sentinel-core/slot/base/default_slot_chain_impl.cc
+++ b/sentinel-core/slot/base/default_slot_chain_impl.cc
@@ -17,9 +17,10 @@ void DefaultSlotChainImpl::AddLast(std::unique_ptr<Slot>&& slot) {
 TokenResultSharedPtr DefaultSlotChainImpl::Entry(
     const EntrySharedPtr& entry, const ResourceWrapperSharedPtr& resource,
     Stat::NodeSharedPtr& node, int count, int flag) {
+  auto context = entry != nullptr ? entry->context() : nullptr;
   auto token_result = TokenResult::Ok();
   for (auto elem = slots_.begin(); elem != slots_.end(); ++elem) {
-    if ((*elem)->IsContinue(token_result)) {
+    if ((*elem)->IsContinue(token_result, context)) {
       token_result = (*elem)->Entry(entry, resource, node, count, flag);
     }
   }

--- a/sentinel-core/slot/base/rule_checker_slot.h
+++ b/sentinel-core/slot/base/rule_checker_slot.h
@@ -10,7 +10,8 @@ namespace Slot {
 class RuleCheckerSlot : public Slot {
  public:
   virtual ~RuleCheckerSlot() = default;
-  bool IsContinue(const TokenResultSharedPtr& token) override {
+  bool IsContinue(const TokenResultSharedPtr& token,
+                  const EntryContextSharedPtr& context) override {
     if (token->status() != TokenStatus::RESULT_STATUS_OK) {
       return false;
     }

--- a/sentinel-core/slot/base/slot.h
+++ b/sentinel-core/slot/base/slot.h
@@ -8,12 +8,14 @@ namespace Slot {
 enum class SlotType {
   RULE_CHECKER_SLOT,
   STATS_SLOT,
+  STATS_PREPARE_SLOT,
 };
 
 class Slot : public SlotBase {
  public:
   virtual ~Slot() = default;
-  virtual bool IsContinue(const TokenResultSharedPtr& token) = 0;
+  virtual bool IsContinue(const TokenResultSharedPtr& token,
+                          const EntryContextSharedPtr& context) = 0;
   virtual const std::string& Name() const = 0;
   virtual SlotType Type() const = 0;
 };

--- a/sentinel-core/slot/base/stats_slot.h
+++ b/sentinel-core/slot/base/stats_slot.h
@@ -10,13 +10,17 @@ namespace Slot {
 class StatsSlot : public Slot {
  public:
   virtual ~StatsSlot() = default;
+
   /*
    * Statistics class slot default always continue the rest of the slot
    * TODO(tianqian.zyf): TokenResultSharedPtr should be passed over the entire
    * slot chain using the SlotChainContext method.
    */
-  bool IsContinue(const TokenResultSharedPtr& token) override {
-    last_token_result_ = token;
+  bool IsContinue(const TokenResultSharedPtr& token,
+                  const EntryContextSharedPtr& context) override {
+    if (context != nullptr) {
+      context->set_last_token_result(token);
+    }
     return true;
   }
 
@@ -24,10 +28,6 @@ class StatsSlot : public Slot {
     static constexpr SlotType type = SlotType::STATS_SLOT;
     return type;
   }
-
- protected:
-  const TokenResultSharedPtr& LastTokenResult() { return last_token_result_; }
-  TokenResultSharedPtr last_token_result_;
 };
 
 }  // namespace Slot

--- a/sentinel-core/slot/base/stats_slot.h
+++ b/sentinel-core/slot/base/stats_slot.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <assert.h>
 #include <string>
 
 #include "sentinel-core/slot/base/slot.h"
@@ -18,6 +19,8 @@ class StatsSlot : public Slot {
    */
   bool IsContinue(const TokenResultSharedPtr& token,
                   const EntryContextSharedPtr& context) override {
+    assert(context != nullptr);
+    // We need to check nullptr to prevent unexpected circumstances.
     if (context != nullptr) {
       context->set_last_token_result(token);
     }

--- a/sentinel-core/slot/statistic_slot.cc
+++ b/sentinel-core/slot/statistic_slot.cc
@@ -64,7 +64,10 @@ TokenResultSharedPtr StatisticSlot::OnBlock(
 TokenResultSharedPtr StatisticSlot::Entry(
     const EntrySharedPtr& entry, const ResourceWrapperSharedPtr& resource,
     /*const*/ Stat::NodeSharedPtr& node, int count, int flag) {
-  TokenResultSharedPtr prev_result = this->LastTokenResult();
+  if (entry == nullptr || entry->context() == nullptr) {
+    return OnPass(entry, resource, node, count, flag);
+  }
+  TokenResultSharedPtr prev_result = entry->context()->last_token_result();
   if (prev_result == nullptr) {
     return OnPass(entry, resource, node, count, flag);
   }

--- a/sentinel-core/slot/statistic_slot_test.cc
+++ b/sentinel-core/slot/statistic_slot_test.cc
@@ -29,7 +29,7 @@ TEST(StatisticSlotTest, TestEntryAndExitSingleThread) {
 
   // Make the slot pass.
   auto pass_result = TokenResult::Ok();
-  slot.IsContinue(pass_result);
+  slot.IsContinue(pass_result, context);
 
   auto result1 = slot.Entry(entry, resource, node, 1, 0);
   EXPECT_EQ(TokenStatus::RESULT_STATUS_OK, result1->status());
@@ -48,7 +48,7 @@ TEST(StatisticSlotTest, TestEntryAndExitSingleThread) {
   // Make the slot block.
   const std::string error_msg = "SomeBlockException";
   auto block_result = TokenResult::Blocked(error_msg);
-  slot.IsContinue(block_result);
+  slot.IsContinue(block_result, context);
 
   auto result2 = slot.Entry(entry, resource, node, 1, 0);
   EXPECT_EQ(TokenStatus::RESULT_STATUS_BLOCKED, result2->status());


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Fix the concurrent problem of passing the last token result in `Slot::StatsSlot`. The slot is global and will be visited by all entries of all resources, so if we cache the `last_token_result` in the universal slot, unexpected errors will happen (core dump on `tiny_free_list_remove_ptr`).

### Does this pull request fix one issue?

NONE

### Describe how you did it

Now that the `EntryContext` is bound with a specific `Entry`, we could pass the last token result via the `EntryContext`. The `Slot::IsContinue` method has been refactored to:

```cpp
virtual bool IsContinue(const TokenResultSharedPtr& token, const EntryContextSharedPtr& context)
```

### Describe how to verify it

Run the test cases for regression.

Run the demo to verify the concurrent problem:

```cpp
#include <chrono>
#include <iostream>
#include <string>
#include <thread>

#include "sentinel-core/public/sph_u.h"
#include "sentinel-core/flow/flow_rule_manager.h"

void doEntry() {
  for (int i = 0; i < 100000; i++) {
    auto r = Sentinel::SphU::Entry("abc");
    if (r.IsBlocked()) {
      std::cerr << "b";
    } else {
      std::cout << "\n~~passed~~\n";
    }
    std::this_thread::sleep_for(std::chrono::milliseconds(10));
  }
}

int main() {
  Sentinel::Flow::FlowRule rule1{"abc"};
  rule1.set_count(10);
  Sentinel::Flow::FlowRuleManager::GetInstance().LoadRules({rule1});

  std::thread t1(doEntry);
  std::thread t2(doEntry);
  std::this_thread::sleep_for(std::chrono::milliseconds(5));
  std::thread t3(doEntry);
  std::thread t4(doEntry);
  std::thread t5(doEntry);
  t1.join();
  t2.join();
  t3.join();
  t4.join();
  t5.join();
  return 0;
}
```

### Special notes for reviews

NONE