### PR TITLE
Add on/off switch command handler and fix global chain problem

### DIFF
--- a/sentinel-core/common/BUILD
+++ b/sentinel-core/common/BUILD
@@ -11,6 +11,15 @@ cc_library(
 )
 
 cc_library(
+  name = "global_status",
+  srcs = [
+    "global_status.h",
+    "global_status.cc",
+  ],
+  copts = DEFAULT_COPTS,
+)
+
+cc_library(
   name = "entry_type_enum",
   srcs = [
     "entry_type.h",

--- a/sentinel-core/common/constants.h
+++ b/sentinel-core/common/constants.h
@@ -6,10 +6,10 @@ namespace Constants {
 static constexpr int kDefaultSampleCount = 2;
 static constexpr int kDefaultIntervalMs = 1000;
 
-static constexpr auto kLimitOriginDefault{"default"};
-static constexpr auto kLimitOriginOther{"other"};
+static constexpr const char* kLimitOriginDefault = "default";
+static constexpr const char* kLimitOriginOther = "other";
 
-static constexpr auto kDefaultContextName{"sentinel_default_context"};
+static constexpr const char* kDefaultContextName = "sentinel_default_context";
 
 static constexpr int kMaxAllowedRt = 4900;
 

--- a/sentinel-core/common/entry.h
+++ b/sentinel-core/common/entry.h
@@ -21,6 +21,7 @@ class Entry {
   virtual ~Entry() = default;
 
   friend class EntryResult;
+  friend class SphU;
 
   ResourceWrapperSharedPtr resource() const { return resource_; }
   std::chrono::milliseconds create_time() const { return create_time_; }

--- a/sentinel-core/common/global_status.cc
+++ b/sentinel-core/common/global_status.cc
@@ -1,0 +1,7 @@
+namespace Sentinel {
+namespace GlobalStatus {
+
+bool activated = true;
+
+};  // namespace GlobalStatus
+}  // namespace Sentinel

--- a/sentinel-core/common/global_status.h
+++ b/sentinel-core/common/global_status.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace Sentinel {
+namespace GlobalStatus {
+
+extern bool activated;
+
+};  // namespace GlobalStatus
+}  // namespace Sentinel

--- a/sentinel-core/config/local_config.cc
+++ b/sentinel-core/config/local_config.cc
@@ -70,7 +70,9 @@ int32_t LocalConfig::WarmUpColdFactor() const {
   int cold_factor =
       GetInt32(Env::kWarmUpColdFactorKey, kDefaultWarmUpColdFactor);
   if (cold_factor <= 1) {
-    // TODO: warn
+    Log::RecordLog::Warn(
+        "Invalid cold_factor <{}>, fallback with the default cold factor <{}>",
+        cold_factor, kDefaultWarmUpColdFactor);
     cold_factor = kDefaultWarmUpColdFactor;
   }
   return cold_factor;

--- a/sentinel-core/flow/flow_rule_manager.cc
+++ b/sentinel-core/flow/flow_rule_manager.cc
@@ -97,7 +97,7 @@ void FlowRuleManager::RegisterToProperty(
     return;
   }
   std::lock_guard<std::mutex> lck(property_mtx_);
-  // TODO: log
+  Log::RecordLog::Info("Registering new property to FlowRuleManager");
   cur_property_->RemoveListener(kFlowPropertyListenerName);
   cur_property_ = property;
   cur_property_->AddListener(std::make_unique<FlowPropertyListener>());
@@ -140,6 +140,7 @@ void FlowPropertyListener::ConfigUpdate(const FlowRuleList& value,
     absl::WriterMutexLock lck(&(m.update_mtx_));
     m.rule_map_.clear();
     m.traffic_controller_map_.clear();
+    Log::RecordLog::Info("[FlowRuleManager] Flow rules received: []");
     return;
   }
 

--- a/sentinel-core/log/metric/BUILD
+++ b/sentinel-core/log/metric/BUILD
@@ -63,6 +63,7 @@ cc_test(
   copts = TEST_COPTS,
   deps = [
     ":metric_log_lib",
+    "@com_google_absl//absl/time",
     "@com_google_googletest//:gtest_main",
   ],
   linkstatic = 1,

--- a/sentinel-core/log/metric/BUILD
+++ b/sentinel-core/log/metric/BUILD
@@ -15,6 +15,7 @@ cc_library(
   copts = DEFAULT_COPTS,
   deps = [
      "@com_google_absl//absl/strings",
+     "@com_google_absl//absl/time",
      "//sentinel-core/utils:utils_lib",
      "//sentinel-core/utils:file_utils_lib",
      "//sentinel-core/statistic/base:metric_item_lib",

--- a/sentinel-core/log/metric/metric_reader_test.cc
+++ b/sentinel-core/log/metric/metric_reader_test.cc
@@ -3,10 +3,11 @@
 
 #include <cstdio>
 #include <fstream>
-#include <iomanip>
 #include <sstream>
 
 #define private public
+
+#include "absl/time/time.h"
 
 #include "sentinel-core/config/local_config.h"
 #include "sentinel-core/log/log_base.h"
@@ -16,8 +17,6 @@
 #include "sentinel-core/utils/file_utils.h"
 #include "sentinel-core/utils/time_utils.h"
 
-#include <iostream>
-
 namespace Sentinel {
 namespace Log {
 
@@ -25,13 +24,12 @@ TEST(MetricReaderTest, TestReadMetrics) {
   int64_t time = Sentinel::Utils::TimeUtils::CurrentTimeMillis().count();
   MetricTestUtils::TestWriteMetricLog(time);
 
-  std::ostringstream data_ss;
-  std::time_t t(time / 1000);
-  data_ss << std::put_time(std::localtime(&t), "%Y-%m-%d");
+  auto date_str = absl::FormatTime("%Y-%m-%d", absl::FromUnixMillis(time),
+                                   absl::LocalTimeZone());
 
   auto log_file_name = LogBase::GetLogBaseDir() +
                        MetricTestUtils::GetAppName() + "-metrics.log." +
-                       data_ss.str();
+                       date_str;
 
   std::vector<std::string> file_names{log_file_name};
   MetricReader reader;
@@ -48,13 +46,12 @@ TEST(MetricReaderTest, TestReadMetricsByEndTime) {
   int64_t time = Sentinel::Utils::TimeUtils::CurrentTimeMillis().count();
   MetricTestUtils::TestWriteMetricLog(time);
 
-  std::ostringstream data_ss;
-  std::time_t t(time / 1000);
-  data_ss << std::put_time(std::localtime(&t), "%Y-%m-%d");
+  auto date_str = absl::FormatTime("%Y-%m-%d", absl::FromUnixMillis(time),
+                                   absl::LocalTimeZone());
 
   auto log_file_name = LogBase::GetLogBaseDir() +
                        MetricTestUtils::GetAppName() + "-metrics.log." +
-                       data_ss.str();
+                       date_str;
 
   std::vector<std::string> file_names{log_file_name};
   MetricReader reader;

--- a/sentinel-core/log/metric/metric_writer.cc
+++ b/sentinel-core/log/metric/metric_writer.cc
@@ -1,7 +1,5 @@
 #include "sentinel-core/log/metric/metric_writer.h"
 
-#include "sentinel-core/config/local_config.h"
-
 #include <dirent.h>
 #include <unistd.h>
 
@@ -19,13 +17,11 @@
 #include "absl/strings/string_view.h"
 #include "absl/time/time.h"
 
+#include "sentinel-core/config/local_config.h"
 #include "sentinel-core/log/log_base.h"
 #include "sentinel-core/log/record_log.h"
-
 #include "sentinel-core/utils/file_utils.h"
 #include "sentinel-core/utils/time_utils.h"
-
-#include <iostream>
 
 using namespace Sentinel::Utils;
 

--- a/sentinel-core/property/dynamic_sentinel_property.h
+++ b/sentinel-core/property/dynamic_sentinel_property.h
@@ -24,10 +24,11 @@ class DynamicSentinelProperty : public SentinelProperty<T> {
   }
 
   bool UpdateValue(const T& value) override {
-    if (laste_value == value) {
+    if (last_value_ == value) {
       return false;
     }
 
+    last_value_ = value;
     for (auto it = listeners_.begin(); it != listeners_.end(); ++it) {
       it->second->ConfigUpdate(value, false);
     }
@@ -38,7 +39,7 @@ class DynamicSentinelProperty : public SentinelProperty<T> {
   void Clear() { listeners_.clear(); }
 
  private:
-  T laste_value;
+  T last_value_;
   std::unordered_map<std::string, PropertyListenerPtr<T>> listeners_;
 };
 }  // namespace Property

--- a/sentinel-core/public/BUILD
+++ b/sentinel-core/public/BUILD
@@ -11,6 +11,7 @@ cc_library(
   copts = DEFAULT_COPTS,
   deps = [
     "//sentinel-core/common:constants",
+    "//sentinel-core/common:global_status",
     "//sentinel-core/common:entry_type_enum",
     "//sentinel-core/common:entry_result_lib",
     "//sentinel-core/common:string_resource_wrapper_lib",

--- a/sentinel-core/public/sph_u.cc
+++ b/sentinel-core/public/sph_u.cc
@@ -2,6 +2,7 @@
 
 #include "sentinel-core/common/constants.h"
 #include "sentinel-core/common/entry.h"
+#include "sentinel-core/common/global_status.h"
 #include "sentinel-core/common/string_resource_wrapper.h"
 #include "sentinel-core/public/sph_u.h"
 #include "sentinel-core/slot/base/slot_chain.h"
@@ -14,6 +15,10 @@ EntryResultPtr SphU::Entry(const EntryContextSharedPtr& context,
                            int flag) {
   auto resource = std::make_shared<StringResourceWrapper>(r, t);
   EntrySharedPtr e = std::make_shared<Sentinel::Entry>(resource, context);
+  if (!GlobalStatus::activated) {
+    e->exited_ = true;
+    return std::make_unique<EntryResult>(e);
+  }
 
   Slot::SlotChainSharedPtr chain = Slot::GlobalSlotChain;
   if (chain == nullptr) {

--- a/sentinel-core/slot/BUILD
+++ b/sentinel-core/slot/BUILD
@@ -46,6 +46,7 @@ cc_library(
   name = "global_slot_chain_header",
   srcs = [
     "global_slot_chain.h",
+    "global_slot_chain.cc",
   ],
   copts = DEFAULT_COPTS,
   deps = [

--- a/sentinel-core/slot/global_slot_chain.cc
+++ b/sentinel-core/slot/global_slot_chain.cc
@@ -1,0 +1,9 @@
+#include "sentinel-core/slot/global_slot_chain.h"
+
+namespace Sentinel {
+namespace Slot {
+
+SlotChainSharedPtr GlobalSlotChain = BuildDefaultSlotChain();
+
+}
+}  // namespace Sentinel

--- a/sentinel-core/slot/global_slot_chain.h
+++ b/sentinel-core/slot/global_slot_chain.h
@@ -18,7 +18,7 @@ static SlotChainSharedPtr BuildDefaultSlotChain() {
   return chain;
 }
 
-static SlotChainSharedPtr GlobalSlotChain = BuildDefaultSlotChain();
+extern SlotChainSharedPtr GlobalSlotChain;
 
 }  // namespace Slot
 }  // namespace Sentinel

--- a/sentinel-core/transport/command/BUILD
+++ b/sentinel-core/transport/command/BUILD
@@ -89,6 +89,7 @@ cc_library(
         "//sentinel-core/transport:transport_constants",
         "//sentinel-core/transport/command/handler:fetch_metric_log_handler_lib",
         "//sentinel-core/transport/command/handler:fetch_cluster_node_handler_lib",
+        "//sentinel-core/transport/command/handler:sentinel_on_off_switch_handler_lib",
         "@com_google_absl//absl/strings",
     ],
 )

--- a/sentinel-core/transport/command/command_handler.h
+++ b/sentinel-core/transport/command/command_handler.h
@@ -12,7 +12,7 @@ class CommandHandler {
  public:
   CommandHandler(const std::string& name) : command_name_(name) {}
   virtual ~CommandHandler() = default;
-  virtual CommandResponseSharedPtr Handle(const CommandRequest& request) = 0;
+  virtual CommandResponsePtr Handle(const CommandRequest& request) = 0;
 
   const std::string& command_name() const { return command_name_; }
 

--- a/sentinel-core/transport/command/command_response.h
+++ b/sentinel-core/transport/command/command_response.h
@@ -8,18 +8,19 @@ namespace Transport {
 
 class CommandResponse;
 using CommandResponseSharedPtr = std::shared_ptr<CommandResponse>;
+using CommandResponsePtr = std::unique_ptr<CommandResponse>;
 
 class CommandResponse {
  public:
   CommandResponse(bool success, const std::string& result)
       : success_(success), result_(result) {}
 
-  static CommandResponseSharedPtr OfSuccess(const std::string& result) {
-    return std::make_shared<CommandResponse>(true, result);
+  static CommandResponsePtr OfSuccess(const std::string& result) {
+    return std::make_unique<CommandResponse>(true, result);
   }
 
-  static CommandResponseSharedPtr OfFailure(const std::string& result) {
-    return std::make_shared<CommandResponse>(false, result);
+  static CommandResponsePtr OfFailure(const std::string& result) {
+    return std::make_unique<CommandResponse>(false, result);
   }
 
   bool success() const { return success_; }

--- a/sentinel-core/transport/command/handler/BUILD
+++ b/sentinel-core/transport/command/handler/BUILD
@@ -44,6 +44,7 @@ cc_library(
   ],
   copts = DEFAULT_COPTS,
   deps = [
+    "@com_google_absl//absl/strings:str_format",
     "//sentinel-core/common:global_status",
     "//sentinel-core/transport/command:command_handler_interface",
   ]

--- a/sentinel-core/transport/command/handler/BUILD
+++ b/sentinel-core/transport/command/handler/BUILD
@@ -33,3 +33,18 @@ cc_library(
     "//sentinel-core/transport/command/handler/vo:statistic_node_vo_lib",
   ]
 )
+
+cc_library(
+  name = "sentinel_on_off_switch_handler_lib",
+  srcs = [
+    "get_switch_status_handler.h",
+    "get_switch_status_handler.cc",
+    "set_switch_status_handler.h",
+    "set_switch_status_handler.cc",
+  ],
+  copts = DEFAULT_COPTS,
+  deps = [
+    "//sentinel-core/common:global_status",
+    "//sentinel-core/transport/command:command_handler_interface",
+  ]
+)

--- a/sentinel-core/transport/command/handler/BUILD
+++ b/sentinel-core/transport/command/handler/BUILD
@@ -48,3 +48,16 @@ cc_library(
     "//sentinel-core/transport/command:command_handler_interface",
   ]
 )
+
+cc_test(
+  name = "sentinel_on_off_switch_handler_unittests",
+  srcs = [
+      "set_switch_status_handler_test.cc",
+  ],
+  copts = TEST_COPTS,
+  deps = [
+    ":sentinel_on_off_switch_handler_lib",
+    "//sentinel-core/common:global_status",
+    "@com_google_googletest//:gtest_main",
+  ],
+)

--- a/sentinel-core/transport/command/handler/fetch_cluster_node_handler.cc
+++ b/sentinel-core/transport/command/handler/fetch_cluster_node_handler.cc
@@ -30,7 +30,7 @@ nlohmann::json ConvertNodeVoToJson(
                         {"timestamp", node->timestamp()}};
 }
 
-CommandResponseSharedPtr FetchClusterNodeCommandHandler::Handle(
+CommandResponsePtr FetchClusterNodeCommandHandler::Handle(
     const CommandRequest& request) {
   std::string type = request.GetParam("type");
   std::vector<std::shared_ptr<StatisticNodeVO>> vec;

--- a/sentinel-core/transport/command/handler/fetch_cluster_node_handler.h
+++ b/sentinel-core/transport/command/handler/fetch_cluster_node_handler.h
@@ -12,8 +12,7 @@ class FetchClusterNodeCommandHandler : public CommandHandler {
   FetchClusterNodeCommandHandler() : CommandHandler("clusterNode") {}
 
   virtual ~FetchClusterNodeCommandHandler() = default;
-  std::shared_ptr<CommandResponse> Handle(
-      const CommandRequest& request) override;
+  CommandResponsePtr Handle(const CommandRequest& request) override;
 };
 
 }  // namespace Transport

--- a/sentinel-core/transport/command/handler/fetch_metric_log_handler.cc
+++ b/sentinel-core/transport/command/handler/fetch_metric_log_handler.cc
@@ -25,7 +25,7 @@ int64_t ParseOrDefault(const std::string& s, int64_t default_value) {
   return x;
 }
 
-std::shared_ptr<CommandResponse> FetchMetricLogCommandHandler::Handle(
+CommandResponsePtr FetchMetricLogCommandHandler::Handle(
     const CommandRequest& request) {
   std::string start_time_str = request.GetParam(kStartTimeKey);
   std::string end_time_str = request.GetParam(kEndTimeKey);

--- a/sentinel-core/transport/command/handler/fetch_metric_log_handler.h
+++ b/sentinel-core/transport/command/handler/fetch_metric_log_handler.h
@@ -22,8 +22,7 @@ class FetchMetricLogCommandHandler : public CommandHandler {
   }
 
   virtual ~FetchMetricLogCommandHandler() = default;
-  std::shared_ptr<CommandResponse> Handle(
-      const CommandRequest& request) override;
+  CommandResponsePtr Handle(const CommandRequest& request) override;
 
  private:
   std::unique_ptr<Log::MetricSearcher> searcher_;

--- a/sentinel-core/transport/command/handler/get_switch_status_handler.cc
+++ b/sentinel-core/transport/command/handler/get_switch_status_handler.cc
@@ -2,15 +2,18 @@
 
 #include <string>
 
+#include "absl/strings/str_format.h"
+
 #include "sentinel-core/common/global_status.h"
 
 namespace Sentinel {
 namespace Transport {
 
-CommandResponseSharedPtr GetSwitchStatusCommandHandler::Handle(
+CommandResponsePtr GetSwitchStatusCommandHandler::Handle(
     const CommandRequest& request) {
   const char* status = GlobalStatus::activated ? "enabled" : "disabled";
-  return CommandResponse::OfSuccess(std::string("Sentinel status: ") + status);
+  return CommandResponse::OfSuccess(
+      absl::StrFormat("Sentinel status: %s", status));
 }
 
 }  // namespace Transport

--- a/sentinel-core/transport/command/handler/get_switch_status_handler.cc
+++ b/sentinel-core/transport/command/handler/get_switch_status_handler.cc
@@ -1,0 +1,17 @@
+#include "sentinel-core/transport/command/handler/get_switch_status_handler.h"
+
+#include <string>
+
+#include "sentinel-core/common/global_status.h"
+
+namespace Sentinel {
+namespace Transport {
+
+CommandResponseSharedPtr GetSwitchStatusCommandHandler::Handle(
+    const CommandRequest& request) {
+  const char* status = GlobalStatus::activated ? "enabled" : "disabled";
+  return CommandResponse::OfSuccess(std::string("Sentinel status: ") + status);
+}
+
+}  // namespace Transport
+}  // namespace Sentinel

--- a/sentinel-core/transport/command/handler/get_switch_status_handler.h
+++ b/sentinel-core/transport/command/handler/get_switch_status_handler.h
@@ -9,7 +9,7 @@ namespace Transport {
 
 class GetSwitchStatusCommandHandler : public CommandHandler {
  public:
-  GetSwitchStatusCommandHandler() : CommandHandler("setSwitch") {}
+  GetSwitchStatusCommandHandler() : CommandHandler("getSwitch") {}
 
   virtual ~GetSwitchStatusCommandHandler() = default;
   CommandResponseSharedPtr Handle(const CommandRequest& request) override;

--- a/sentinel-core/transport/command/handler/get_switch_status_handler.h
+++ b/sentinel-core/transport/command/handler/get_switch_status_handler.h
@@ -12,7 +12,7 @@ class GetSwitchStatusCommandHandler : public CommandHandler {
   GetSwitchStatusCommandHandler() : CommandHandler("getSwitch") {}
 
   virtual ~GetSwitchStatusCommandHandler() = default;
-  CommandResponseSharedPtr Handle(const CommandRequest& request) override;
+  CommandResponsePtr Handle(const CommandRequest& request) override;
 };
 
 }  // namespace Transport

--- a/sentinel-core/transport/command/handler/set_switch_status_handler.cc
+++ b/sentinel-core/transport/command/handler/set_switch_status_handler.cc
@@ -5,7 +5,7 @@
 namespace Sentinel {
 namespace Transport {
 
-CommandResponseSharedPtr SetSwitchStatusCommandHandler::Handle(
+CommandResponsePtr SetSwitchStatusCommandHandler::Handle(
     const CommandRequest& request) {
   auto v = request.GetParam("value");
   if (v == "true") {

--- a/sentinel-core/transport/command/handler/set_switch_status_handler.cc
+++ b/sentinel-core/transport/command/handler/set_switch_status_handler.cc
@@ -1,0 +1,25 @@
+#include "sentinel-core/transport/command/handler/set_switch_status_handler.h"
+
+#include "sentinel-core/common/global_status.h"
+
+namespace Sentinel {
+namespace Transport {
+
+CommandResponseSharedPtr SetSwitchStatusCommandHandler::Handle(
+    const CommandRequest& request) {
+  auto v = request.GetParam("value");
+  if (v == "true") {
+    GlobalStatus::activated = true;
+    // Log::RecordLog::Info("[SwitchOnOffHandler] Sentinel has been activated");
+    return CommandResponse::OfSuccess("Sentinel has been enabled");
+  }
+  if (v == "false") {
+    GlobalStatus::activated = false;
+    // Log::RecordLog::Info("[SwitchOnOffHandler] Sentinel has been disabled");
+    return CommandResponse::OfSuccess("Sentinel has been disabled");
+  }
+  return CommandResponse::OfFailure("bad new status");
+}
+
+}  // namespace Transport
+}  // namespace Sentinel

--- a/sentinel-core/transport/command/handler/set_switch_status_handler.h
+++ b/sentinel-core/transport/command/handler/set_switch_status_handler.h
@@ -12,7 +12,7 @@ class SetSwitchStatusCommandHandler : public CommandHandler {
   SetSwitchStatusCommandHandler() : CommandHandler("setSwitch") {}
 
   virtual ~SetSwitchStatusCommandHandler() = default;
-  CommandResponseSharedPtr Handle(const CommandRequest& request) override;
+  CommandResponsePtr Handle(const CommandRequest& request) override;
 };
 
 }  // namespace Transport

--- a/sentinel-core/transport/command/handler/set_switch_status_handler_test.cc
+++ b/sentinel-core/transport/command/handler/set_switch_status_handler_test.cc
@@ -1,0 +1,28 @@
+#include <string>
+
+#include "sentinel-core/common/global_status.h"
+#include "sentinel-core/transport/command/handler/set_switch_status_handler.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace Sentinel {
+namespace Transport {
+
+TEST(SetSwitchStatusCommandHandlerTest, TestHandleRequest) {
+  SetSwitchStatusCommandHandler handler;
+  CommandRequest request;
+  EXPECT_FALSE(handler.Handle(request)->success());
+
+  EXPECT_TRUE(GlobalStatus::activated);
+  request.AddParam("value", "false");
+  EXPECT_TRUE(handler.Handle(request)->success());
+  EXPECT_FALSE(GlobalStatus::activated);
+
+  request.AddParam("value", "true");
+  EXPECT_TRUE(handler.Handle(request)->success());
+  EXPECT_TRUE(GlobalStatus::activated);
+}
+
+}  // namespace Transport
+}  // namespace Sentinel

--- a/sentinel-core/transport/command/http_command_center.cc
+++ b/sentinel-core/transport/command/http_command_center.cc
@@ -55,13 +55,13 @@ void HttpCommandCenter::OnHttpRequest(struct evhttp_request* http_req) {
   }
 
   auto response = it->second->Handle(request);
-  HandleResponse(http_req, response);
+  HandleResponse(http_req, std::move(response));
 
   return;
 }
 
-void HttpCommandCenter::HandleResponse(
-    struct evhttp_request* http_req, const CommandResponseSharedPtr& response) {
+void HttpCommandCenter::HandleResponse(struct evhttp_request* http_req,
+                                       CommandResponsePtr&& response) {
   if (response->success()) {
     HttpCommandUtils::SucessRequest(http_req, response->result());
   } else {

--- a/sentinel-core/transport/command/http_command_center.h
+++ b/sentinel-core/transport/command/http_command_center.h
@@ -23,7 +23,7 @@ class HttpCommandCenter {
  private:
   void OnHttpRequest(struct evhttp_request* http_req);
   void HandleResponse(struct evhttp_request* http_req,
-                      const CommandResponseSharedPtr& response);
+                      CommandResponsePtr&& response);
 
  private:
   std::unique_ptr<HttpServer> http_server_;

--- a/sentinel-core/transport/command/http_server_init_target.cc
+++ b/sentinel-core/transport/command/http_server_init_target.cc
@@ -5,6 +5,8 @@
 
 #include "sentinel-core/transport/command/handler/fetch_cluster_node_handler.h"
 #include "sentinel-core/transport/command/handler/fetch_metric_log_handler.h"
+#include "sentinel-core/transport/command/handler/get_switch_status_handler.h"
+#include "sentinel-core/transport/command/handler/set_switch_status_handler.h"
 #include "sentinel-core/transport/command/http_server_init_target.h"
 #include "sentinel-core/transport/constants.h"
 
@@ -38,6 +40,10 @@ void HttpCommandCenterInitTarget::Initialize() {
       std::make_unique<FetchMetricLogCommandHandler>());
   command_center_->RegisterCommand(
       std::make_unique<FetchClusterNodeCommandHandler>());
+  command_center_->RegisterCommand(
+      std::make_unique<SetSwitchStatusCommandHandler>());
+  command_center_->RegisterCommand(
+      std::make_unique<GetSwitchStatusCommandHandler>());
 
   uint32_t port = GetAvailablePort();
   command_center_->Start(port);


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add on/off switch command handler and fix global chain extern problem.

### Does this pull request fix one issue?

NONE

### Describe how you did it

- Add on/off switch command handler to activate/disable Sentinel
- Fix global chain problem: static namespace scope variable has internal linkage. That means, it cannot be accessed from other translation units. The fix makes GlobalSlotChain as non-static.
- Define the constant string in `Sentinel::Constants` with explicit type (`const char*`) to avoid wrong type inference in some g++ versions
- Use `chrono` and `absl/time` to format date in `MetricWriter` (`std::get_time` is not implemented in gcc 4.9.x)
- Fix the value cache bug of `DynamicSentinelProperty`

### Describe how to verify it

Run the test cases.

### Special notes for reviews

NONE