### PR TITLE
Add back LogSlot to default slot chain

### DIFF
--- a/sentinel-core/slot/global_slot_chain.cc
+++ b/sentinel-core/slot/global_slot_chain.cc
@@ -3,6 +3,7 @@
 
 #include "sentinel-core/flow/flow_slot.h"
 #include "sentinel-core/slot/base/default_slot_chain_impl.h"
+#include "sentinel-core/slot/log_slot.h"
 #include "sentinel-core/slot/resource_node_builder_slot.h"
 #include "sentinel-core/slot/statistic_slot.h"
 
@@ -14,6 +15,7 @@ static SlotChainSharedPtr BuildDefaultSlotChain() {
   chain->AddLast(std::make_unique<ResourceNodeBuilderSlot>());
   chain->AddLast(std::make_unique<FlowSlot>());
   chain->AddLast(std::make_unique<StatisticSlot>());
+  chain->AddLast(std::make_unique<LogSlot>());
   return chain;
 }
 

--- a/sentinel-core/slot/global_slot_chain.h
+++ b/sentinel-core/slot/global_slot_chain.h
@@ -2,11 +2,7 @@
 
 #include <memory>
 
-#include "sentinel-core/flow/flow_slot.h"
-#include "sentinel-core/slot/base/default_slot_chain_impl.h"
-#include "sentinel-core/slot/log_slot.h"
-#include "sentinel-core/slot/resource_node_builder_slot.h"
-#include "sentinel-core/slot/statistic_slot.h"
+#include "sentinel-core/slot/base/slot_chain.h"
 
 namespace Sentinel {
 namespace Slot {


### PR DESCRIPTION
Signed-off-by: Eric Zhao <sczyh16@gmail.com>

<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it

Add back `LogSlot` to the default slot chain.

### Does this pull request fix one issue?

NONE

### Describe how to verify it

Run the demo.