### PR TITLE
Fix the bug that may cause infinite loop when positioning index in MetricSearcher::FindOffset

### DIFF
--- a/sentinel-core/log/metric/metric_searcher.cc
+++ b/sentinel-core/log/metric/metric_searcher.cc
@@ -54,7 +54,7 @@ int64_t MetricSearcher::FindOffset(int64_t begin_time_ms,
   int64_t tmp_offset = -1;
   int64_t offset = -1;
 
-  while (!in.eof()) {
+  while (!in.eof() && !in.fail()) {
     in >> second >> tmp_offset;
     if (second < begin_second) {
       last_pos_.offset_in_index = in.tellg();


### PR DESCRIPTION
<!--  Thanks for submitting a pull request! Here are some tips for you:
1. Please make sure you have read and understood the contributing guidelines: https://github.com/alibaba/Sentinel/blob/master/CONTRIBUTING.md
2. Please make sure the PR has a corresponding issue.
-->

### Describe what this PR does / why we need it
Failbit or badbit cause infinite read file loop in `MetricSearcher::FindOffset`.

### Does this pull request fix one issue?
Fixes #27 
<!--If that, add "Fixes #27 " below in the next line. For example, Fixes #15. Otherwise, add "NONE" -->

### Describe how you did it
If read ifstream fail (`ifstream::fail()`) then jump out.

### Describe how to verify it
Use `ifstream` to open an unexisting file, `ifstream::fail()` returns true value.

### Special notes for reviews
