### PR TITLE
fix: main thread should wait until all child threads exit

### DIFF
--- a/sentinel-core/log/block/block_log_task.h
+++ b/sentinel-core/log/block/block_log_task.h
@@ -5,7 +5,6 @@
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
-#include "absl/synchronization/mutex.h"
 #include "spdlog/spdlog.h"
 
 #include "sentinel-core/log/log_base.h"
@@ -40,6 +39,7 @@ class BlockLogTask {
 
  private:
   std::atomic_bool started_{false};
+  std::unique_ptr<std::thread> thd_;
   std::shared_ptr<spdlog::logger> logger_;
   absl::flat_hash_map<std::string, BlockLogRecord> map_;
   mutable absl::Mutex mtx_;

--- a/sentinel-core/log/metric/metric_log_task.h
+++ b/sentinel-core/log/metric/metric_log_task.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <unordered_map>
@@ -18,14 +19,15 @@ using MetricItemTimeMap =
 class MetricLogTask : public Init::Target {
  public:
   MetricLogTask();
-  virtual ~MetricLogTask() = default;
+  virtual ~MetricLogTask();
   void Initialize() override;
 
   void Stop();
 
  private:
   std::unique_ptr<MetricWriter> writer_;
-  bool stopped_{false};
+  std::atomic<bool> stopped_{false};
+  std::unique_ptr<std::thread> thd_;
 
   void RunLogTask();
   void AggregateMetrics(

--- a/sentinel-core/system/system_status_listener.h
+++ b/sentinel-core/system/system_status_listener.h
@@ -56,11 +56,7 @@ class SystemStatusListener {
     return *instance;
   }
 
-  virtual ~SystemStatusListener() {
-    StopListner();
-    file_stat_.close();
-    file_load_.close();
-  }
+  virtual ~SystemStatusListener();
   void RunCpuListener();
   void Initialize();
   double GetCurLoad() { return cur_load_.load(); }
@@ -80,16 +76,12 @@ class SystemStatusListener {
 
   std::atomic<double> cur_load_{-1};
   std::atomic<double> cur_cpu_usage_{-1};
-  std::atomic<bool> stopped_cmd_{false};
-  std::atomic<bool> stopped_{false};
+  std::atomic<bool> started_{false};
+  std::unique_ptr<std::thread> thd_;
   std::atomic<bool> inited_{false};
 
   // wait until loop in RunCpuListener stop
-  void StopListner() {
-    stopped_cmd_.store(true);
-    while (!stopped_.load())
-      ;
-  }
+  void Stop();
 };
 
 }  // namespace System


### PR DESCRIPTION
### Describe what this PR does / why we need it
In previous version, childs threads (metric log thread, block log thread) are detached. Therefore, end of main thread triggers destruction of global objects. However, child threads do not know this and may be still using the destructed objects, causing segfault.

### Does this pull request fix one issue?
NONE

### Describe how you did it
Instread of detaching child threads, explicitly wait them exit using `join` in destructor.

### Describe how to verify it
Unittests and demos run well.

### Special notes for reviews
